### PR TITLE
fix: fixed domain mapping to return to treafik

### DIFF
--- a/services/config_proxy.go
+++ b/services/config_proxy.go
@@ -64,9 +64,9 @@ type OrderedRouter struct {
 
 // OrderedTLSConfig represents TLS config for a router with Pangolin's field order.
 type OrderedTLSConfig struct {
-	CertResolver string   `json:"certResolver,omitempty"`
-	Domains      []string `json:"domains,omitempty"`
-	Options      string   `json:"options,omitempty"`
+	CertResolver string        `json:"certResolver,omitempty"`
+	Domains      []interface{} `json:"domains,omitempty"`
+	Options      string        `json:"options,omitempty"`
 }
 
 // OrderedMiddleware represents a middleware with Pangolin's field order.
@@ -1261,12 +1261,7 @@ func (cp *ConfigProxy) mapToOrderedTLS(tls map[string]interface{}) *OrderedTLSCo
 	if domains, ok := tls["domains"]; ok {
 		switch v := domains.(type) {
 		case []interface{}:
-			for _, d := range v {
-				if s, ok := d.(string); ok {
-					ordered.Domains = append(ordered.Domains, s)
-				}
-			}
-		case []string:
+			// Preserve original format as-is (strings or objects)
 			ordered.Domains = v
 		}
 	}

--- a/services/config_proxy.go
+++ b/services/config_proxy.go
@@ -1261,8 +1261,17 @@ func (cp *ConfigProxy) mapToOrderedTLS(tls map[string]interface{}) *OrderedTLSCo
 	if domains, ok := tls["domains"]; ok {
 		switch v := domains.(type) {
 		case []interface{}:
-			// Preserve original format as-is (strings or objects)
 			ordered.Domains = v
+		case []string:
+			ordered.Domains = make([]interface{}, len(v))
+			for i, domain := range v {
+				ordered.Domains[i] = domain
+			}
+		case []map[string]interface{}:
+			ordered.Domains = make([]interface{}, len(v))
+			for i, domain := range v {
+				ordered.Domains[i] = domain
+			}
 		}
 	}
 


### PR DESCRIPTION
The domains object in the TLS field of routers is not being passed though to traefik correctly.
This messes with the ability of Traefik to create wildcard domains.

Response from pangolin (expected from MM too):
```json
{
    "http": {
        "middlewares": {
            ...
        },
        "routers": {
            "8-example-router": {
                "entryPoints": [
                    "websecure"
                ],
                "middlewares": [
                    "badger"
                ],
                "service": "8-example-service",
                "rule": "Host(`target.example.com`)",
                "priority": 100,
                "tls": {
                    "certResolver": "letsencrypt",
                    "domains": [
                        {
                            "main": "*.example.com"
                        }
                    ]
                }
            },
        },
        "services": {
			...
        }
    }
```
Response from Middleware Manager:
```json
{
    "http": {
        "middlewares": {
            ...
        },
        "routers": {
            "8-example-router": {
                "entryPoints": [
                    "websecure"
                ],
                "middlewares": [
                    "badger"
                ],
                "service": "8-example-service",
                "rule": "Host(`target.example.com`)",
                "priority": 100,
                "tls": {
                    "certResolver": "letsencrypt"
                }
            },
        },
        "services": {
			...
        }
    }
```

This PR should address the issue.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * TLS domain configurations now preserve mixed entries, keeping both plain string domains and structured domain objects intact.
  * Ordered TLS output has been updated to retain the original domain configuration format without stripping non-string items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->